### PR TITLE
Rearranging The Remote Plugins Based On Project Activity

### DIFF
--- a/blog/news/_posts/2018-09-03-safe-remote-access.md
+++ b/blog/news/_posts/2018-09-03-safe-remote-access.md
@@ -38,6 +38,10 @@ Setup is relatively simple, install the plugin, either from the Plugin Manager, 
 
 The Spaghetti Detective has replaced the formerly mentioned OctoPrint Anywhere.
 
+#### OctoEverywhere! (*edit: added 2021-01-05*)
+
+[OctoEverywhere.com](https://octoeverywhere.com/?source=octoprint_blog) is a <strong>free, secure, and easy</strong> to use cloud service that allows you to access your entire OctoPrint web portal from anywhere! OctoEverywhere is a community funded effort that focuses empowering everyone to create better with full remote access to their OctoPrint setup. The service supports webcam streaming, remote printer control, full plugin support, and more! To start the 2-minute setup process go [here](https://octoeverywhere.com/getStarted?source=octoprint_blog), or checkout the official plugin listed [here](https://plugins.octoprint.org/plugins/octoeverywhere/).
+
 #### OctoPrint-DiscordRemote
 
 If you're a discord user, the DiscordRemote plugin is another option. It will join your discord channel,
@@ -50,10 +54,6 @@ The telegram plugin operates similarly to the DiscordRemote plugin, in that it c
 #### ngrok (*edit: added 2020-06-22*)
 
 The plugin creates a secure tunnel to access OctoPrint remotely through [ngrok](https://ngrok.com/). The tunnel is encrypted with SSL and proper certificates (even if your OctoPrint instance is not accessible via HTTPS locally), and is further protected with Basic Authentication (username and password) out of the box. It pretty much wraps the "Reverse Proxy" scenario from below into an easily installable plugin.
-
-#### OctoEverywhere.com (*edit: added 2021-01-05*)
-
-[OctoEverywhere.com](https://octoeverywhere.com/?source=octoprint_blog) is a free, secure, and easy to use cloud service that allows you to access your entire OctoPrint web portal from anywhere! OctoEverywhere is a community funded effort that focuses empowering everyone to create better with full remote access to their OctoPrint setup. The service supports webcam streaming, remote printer control, full plugin support, and more! To start the 2-minute setup process go [here](https://octoeverywhere.com/getStarted?source=octoprint_blog), or checkout the official plugin listed [here](https://plugins.octoprint.org/plugins/octoeverywhere/).
 
 ### Advanced Access
 


### PR DESCRIPTION
Recently this post was fixed up and the block of text for my OctoEverywhere plugin was moved to the bottom of the list. Surprisingly, this dramatically dropped the discovery of my service from this website, which is one of the main traffic flows for new users. 

Since my project is still trying to establish itself, new users coming into the project are critical for its success. Since my community project is not super widely known, it's still not very discoverable online at the moment. For example, if you search "octoprint remote access" on Google it doesn't even show up beyond it being referenced in this post (despite how hard I have been trying).

Anyways, in this change I moved the info for OctoEverywhere up higher in the plugin list, hoping that it will resume more of the traffic from this source. I looked at the other plugins listed and tried to be respectful of the placement of each and how active their project seems to be. To me, sorting by the project activity seems to be fair, but I'm open to feedback. :)