### PR TITLE
Remove octoprint_install, modify octoprint_deploy

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -200,7 +200,7 @@ more details on usage and configuration.
 
 # octoprint_deploy (Linux)
 
-[octoprint_deploy](https://github.com/paukstelis/octoprint_deploy) is a guided script for installing OctoPrint, video streamers, haproxy, etc on virtually any Linux system. It guides the user through creation of one or more OctoPrint instances. Creating multiple instances with the script allows control of multiple printers on a single piece of hardware. It is compatible with OctoPi.
+[octoprint_deploy](https://github.com/paukstelis/octoprint_deploy) is a guided script for installing OctoPrint and additional tools (video streamer, haproxy) on virtually any Linux system. It guides the user through creation of one or more OctoPrint instances. Creating multiple instances with the script allows control of multiple printers on a single piece of hardware. A variety of utilities improve the multi-instance experience, including automated creation of udev rules, syncing users between instances, and sharing file uploads between instances. It is compatible with OctoPi.
 
 Maintained by [Paul Paukstelis](https://github.com/paukstelis).
 

--- a/download/index.md
+++ b/download/index.md
@@ -6,7 +6,7 @@ description: Learn how to setup OctoPrint using the preinstalled OctoPi image fo
 ---
 
 <center>
-  <a href="#octopi">OctoPi (Raspberry Pi)</a> &middot; <a href="#octo4a">Octo4a (Android)</a> &middot; <a href="#octoprint-for-orange-pi">OctoPrint for Orange Pi</a> &middot; <a href="#docker">Docker install</a> &middot; <a href="#octoprint_install--octoprint_deploy-linux">octoprint_install & octoprint_deploy (Linux)</a> &middot; <a href="#windows-installer">Windows Installer</a> &middot; <a href="#installing-manually">Manual install (Linux, Windows, Mac)</a>
+  <a href="#octopi">OctoPi (Raspberry Pi)</a> &middot; <a href="#octo4a">Octo4a (Android)</a> &middot; <a href="#octoprint-for-orange-pi">OctoPrint for Orange Pi</a> &middot; <a href="#docker">Docker install</a> &middot; <a href="#octoprint_deploy-linux">octoprint_deploy (Linux)</a> &middot; <a href="#windows-installer">Windows Installer</a> &middot; <a href="#installing-manually">Manual install (Linux, Windows, Mac)</a>
 </center>
 
 # OctoPi
@@ -198,15 +198,11 @@ more details on usage and configuration.
 
 ----
 
-# octoprint_install & octoprint_deploy (Linux)
-[octoprint_install](https://github.com/paukstelis/octoprint_install) is a guided script for setting up OctoPrint and a webcam streamer on
-virtually any Linux system. For those without a Linux background it provides the simplest solution to getting OctoPrint up and running.
+# octoprint_deploy (Linux)
 
-[octoprint_deploy](https://github.com/paukstelis/octoprint_deploy) is a guided script for creating multiple OctoPrint instances.
-This enables control of multiple printers on a single piece of hardware. It is compatible with OctoPi and also functions as a 
-general Linux installer for OctoPrint, video streamers, haproxy, etc.
+[octoprint_deploy](https://github.com/paukstelis/octoprint_deploy) is a guided script for installing OctoPrint, video streamers, haproxy, etc on virtually any Linux system. It guides the user through creation of one or more OctoPrint instances. Creating multiple instances with the script allows control of multiple printers on a single piece of hardware. It is compatible with OctoPi.
 
-Both are maintained by [Paul Paukstelis](https://github.com/paukstelis).
+Maintained by [Paul Paukstelis](https://github.com/paukstelis).
 
 ----
 


### PR DESCRIPTION
octoprint_install has been merged into octoprint_deploy so that only one script has to be maintained. This PR reflects that change.